### PR TITLE
Improvement/initial grace period

### DIFF
--- a/src/main/java/dev/hollink/bankstanding/BankstandingPlugin.java
+++ b/src/main/java/dev/hollink/bankstanding/BankstandingPlugin.java
@@ -17,6 +17,7 @@ import java.awt.image.BufferedImage;
 import java.util.List;
 import java.util.Objects;
 import javax.inject.Inject;
+import javax.inject.Named;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
@@ -68,6 +69,10 @@ public class BankstandingPlugin extends Plugin
 	@Inject
 	private LevelUpHandler levelUpHandler;
 
+	@Inject
+	@Named("developerMode")
+	private boolean developerMode;
+
 	@Getter
 	@Inject
 	private BankstandingPanel bankStatsPanel;
@@ -87,8 +92,11 @@ public class BankstandingPlugin extends Plugin
 		levelUpHandler.init();
 
 		chatCommandManager.registerCommand("!lvl", chatCommandHandler::handleLevelCommand);
-		clientToolbar.addNavigation(navButton = buildNavButton());
+		if (developerMode) {
+			chatCommandManager.registerCommand("!setBankstanding", chatCommandHandler::handleSetLevelCommand);
+		}
 
+		clientToolbar.addNavigation(navButton = buildNavButton());
 	}
 
 	@Override
@@ -102,6 +110,10 @@ public class BankstandingPlugin extends Plugin
 		progressOverlayStateManager.destroy();
 
 		chatCommandManager.unregisterCommand("!lvl");
+		if (developerMode) {
+			chatCommandManager.unregisterCommand("!setBankstanding");
+		}
+
 		clientToolbar.removeNavigation(navButton);
 	}
 

--- a/src/main/java/dev/hollink/bankstanding/overlay/ExperienceOverlayStateManager.java
+++ b/src/main/java/dev/hollink/bankstanding/overlay/ExperienceOverlayStateManager.java
@@ -84,6 +84,13 @@ public class ExperienceOverlayStateManager
 		}
 	}
 
+	public void refreshExperience()
+	{
+		BankstandingLevel bankstanding = experienceManager.getBankstanding();
+		updateInternalState(bankstanding.getCurrentLevel(), bankstanding.getExperience());
+		lastExpDrop = Instant.now();
+	}
+
 	private void updateInternalState(int currentLevel, double currentExperience)
 	{
 		int xpAtStartOfLevel = Experience.getXpForLevel(currentLevel);

--- a/src/main/java/dev/hollink/bankstanding/overlay/debug/PlayerStateDebugOverlay.java
+++ b/src/main/java/dev/hollink/bankstanding/overlay/debug/PlayerStateDebugOverlay.java
@@ -79,6 +79,8 @@ public class PlayerStateDebugOverlay extends OverlayPanel implements OverlayHelp
 		PlayerState currentPlayerState = stateManager.getCurrentPlayerState();
 		switch (currentPlayerState.getActivity())
 		{
+			case NULL:
+				return secondsSince(stateManager.getCurrentPlayerState().getSince(), TIME_TILL_INITIAL_EXP);
 			case CHATTING:
 				return secondsSince(stateManager.getLastChatMessage(), GRACE_PERIOD_CHATTING);
 			case LOAFING:
@@ -89,24 +91,21 @@ public class PlayerStateDebugOverlay extends OverlayPanel implements OverlayHelp
 		return 0;
 	}
 
-
 	public long timeTillExpDrop()
 	{
-		long secondsTillInitialDrop = Duration.between(Instant.now(), xpManager.getLastStateChange().plus(TIME_TILL_INITIAL_EXP)).toSeconds();
-		if (secondsTillInitialDrop > 0)
-		{
-			return secondsTillInitialDrop;
-		}
-		else
-		{
-			long secondsTillNextExpDrop = Duration.between(Instant.now(), xpManager.getLastExpDrop().plus(TIME_BETWEEN_DROPS)).toSeconds();
-			return Math.max(secondsTillNextExpDrop, 0);
-		}
+		long secondsTillNextExpDrop = Duration.between(Instant.now(), xpManager.getLastExpDrop().plus(TIME_BETWEEN_DROPS)).toSeconds();
+		return Math.max(secondsTillNextExpDrop, 0);
+	}
+
+	private long secondsSince(Instant from, Duration gracePeriod)
+	{
+		long secondsTillNextExpDrop = Duration.between(Instant.now(), from.plus(gracePeriod)).toSeconds();
+		return Math.max(secondsTillNextExpDrop, 0);
 	}
 
 	private long secondsSince(Activity<?> activity, Duration gracePeriod)
 	{
-		return Duration.between(Instant.now(), activity.getTime().plus(gracePeriod)).toSeconds();
+		return secondsSince(activity.getTime(), gracePeriod);
 	}
 
 	private String enumToString(String name)

--- a/src/main/java/dev/hollink/bankstanding/state/ChatCommandHandler.java
+++ b/src/main/java/dev/hollink/bankstanding/state/ChatCommandHandler.java
@@ -1,6 +1,7 @@
 package dev.hollink.bankstanding.state;
 
 import dev.hollink.bankstanding.state.level.LevelCommandHandler;
+import dev.hollink.bankstanding.state.level.LevelSetCommandHandler;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.RequiredArgsConstructor;
@@ -14,9 +15,19 @@ import net.runelite.api.events.ChatMessage;
 public class ChatCommandHandler
 {
 	private final LevelCommandHandler levelCommandHandler;
+	private final LevelSetCommandHandler setLevelCommandHandler;
 
 	public void handleLevelCommand(ChatMessage chatMessage, String message)
 	{
 		levelCommandHandler.handleCommand(chatMessage, message);
+	}
+
+	public void handleSetLevelCommand(ChatMessage chatMessage, String message) {
+		try {
+			setLevelCommandHandler.handleCommand(chatMessage, message);
+		}
+		catch (IllegalArgumentException e) {
+			log.warn(e.getMessage());
+		}
 	}
 }

--- a/src/main/java/dev/hollink/bankstanding/state/bankstats/BankStatsManager.java
+++ b/src/main/java/dev/hollink/bankstanding/state/bankstats/BankStatsManager.java
@@ -122,7 +122,7 @@ public class BankStatsManager
 			{
 				allTimeStats.clear();
 				allTimeStats.putAll(loaded);
-				logSaveDataLoaded(loaded);
+				logSaveData(loaded, "Loaded saved data...");
 			}
 		}
 		catch (Exception ex)
@@ -131,15 +131,15 @@ public class BankStatsManager
 		}
 	}
 
-	private void logSaveDataLoaded(Map<BankLocation, BankStats> loaded)
+	private void logSaveData(Map<BankLocation, BankStats> loaded, String message)
 	{
 		if (config.debugLogSaveData())
 		{
-			log.debug("Loaded saved data... {}", loaded);
+			log.debug("{} {}", message, loaded);
 		}
 		else
 		{
-			log.debug("Loaded saved data...");
+			log.debug(message);
 		}
 	}
 
@@ -154,7 +154,7 @@ public class BankStatsManager
 	public void saveData()
 	{
 		String data = gson.toJson(allTimeStats);
-		log.debug("Saving data... {}", data);
+		logSaveData(allTimeStats, "Saving data...");
 		configManager.setRSProfileConfiguration(BankstandingConfig.CONFIG_GROUP, "bankStats", data);
 	}
 

--- a/src/main/java/dev/hollink/bankstanding/state/level/ExperienceManager.java
+++ b/src/main/java/dev/hollink/bankstanding/state/level/ExperienceManager.java
@@ -16,6 +16,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.Player;
@@ -25,7 +26,6 @@ import net.runelite.client.config.ConfigManager;
 import static dev.hollink.bankstanding.BankstandingConfig.CONFIG_GROUP;
 import static dev.hollink.bankstanding.BankstandingConfig.CURRENT_EXPERIENCE_CONFIG_KEY;
 import static dev.hollink.bankstanding.config.ExpRateConstants.TIME_BETWEEN_DROPS;
-import static dev.hollink.bankstanding.config.TimeConstants.TIME_TILL_INITIAL_EXP;
 
 @Slf4j
 @Singleton
@@ -47,6 +47,7 @@ public class ExperienceManager
 	private ActivityState lastState = ActivityState.GRINDING;
 
 	@Getter
+	@Setter
 	private BankstandingLevel bankstanding = new BankstandingLevel(0);
 
 	public void init()
@@ -102,12 +103,6 @@ public class ExperienceManager
 		}
 
 		Instant now = Instant.now();
-		Duration timeInState = Duration.between(lastStateChange, now);
-		if (timeInState.compareTo(TIME_TILL_INITIAL_EXP) < 0)
-		{
-			return;
-		}
-
 		if (Duration.between(lastExpDrop, now).compareTo(TIME_BETWEEN_DROPS) >= 0)
 		{
 			double granted = grantExperience(lastState);

--- a/src/main/java/dev/hollink/bankstanding/state/level/LevelCommandHandler.java
+++ b/src/main/java/dev/hollink/bankstanding/state/level/LevelCommandHandler.java
@@ -56,7 +56,6 @@ public class LevelCommandHandler implements CommandHandler
 		}
 
 		String category = args[1].toLowerCase();
-		log.debug("Received level command: {}", category);
 		switch (category)
 		{
 			case "bs":

--- a/src/main/java/dev/hollink/bankstanding/state/level/LevelSetCommandHandler.java
+++ b/src/main/java/dev/hollink/bankstanding/state/level/LevelSetCommandHandler.java
@@ -1,0 +1,106 @@
+package dev.hollink.bankstanding.state.level;
+
+import dev.hollink.bankstanding.domain.BankstandingLevel;
+import dev.hollink.bankstanding.overlay.ExperienceOverlayStateManager;
+import dev.hollink.bankstanding.state.CommandHandler;
+import java.util.Arrays;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Experience;
+import net.runelite.api.events.ChatMessage;
+import net.runelite.client.config.ConfigManager;
+
+import static dev.hollink.bankstanding.BankstandingConfig.CONFIG_GROUP;
+import static dev.hollink.bankstanding.BankstandingConfig.CURRENT_EXPERIENCE_CONFIG_KEY;
+
+@Slf4j
+@Singleton
+@RequiredArgsConstructor(onConstructor = @__(@Inject))
+public class LevelSetCommandHandler implements CommandHandler
+{
+	private final ConfigManager configManager;
+	private final ExperienceManager xpManager;
+	private final ExperienceOverlayStateManager overlay;
+
+
+	public void handleCommand(ChatMessage chatMessage, String message)
+		throws InvalidValueArgumentException, InvalidTypeArgumentException
+	{
+		String[] args = message.split(" ");
+
+		log.debug("Received set level command: {}", Arrays.toString(args));
+		if (args.length != 3)
+		{
+			return;
+		}
+
+		String type = args[1].toLowerCase();
+		int exp = getExperience(type, args[2]);
+
+		setExperience(exp);
+	}
+
+	private int getExperience(String type, String args)
+	{
+		switch (type)
+		{
+			case "level":
+				return Experience.getXpForLevel(getIntValue(args));
+			case "exp":
+				return getIntValue(args);
+			default:
+				throw new InvalidTypeArgumentException(type);
+		}
+	}
+
+	private int getIntValue(String arg)
+	{
+		try
+		{
+			return Integer.parseInt(arg);
+		}
+		catch (NumberFormatException e)
+		{
+			throw new InvalidValueArgumentException(arg);
+		}
+	}
+
+	private void setExperience(int experience)
+	{
+		log.debug("Setting bankstanding experience to {}", experience);
+		xpManager.setBankstanding(new BankstandingLevel(experience));
+		overlay.refreshExperience();
+		configManager.setRSProfileConfiguration(
+			CONFIG_GROUP,
+			CURRENT_EXPERIENCE_CONFIG_KEY,
+			String.valueOf(experience)
+		);
+	}
+
+	@RequiredArgsConstructor
+	public static class InvalidValueArgumentException extends IllegalArgumentException
+	{
+		final String value;
+
+		@Override
+		public String getMessage()
+		{
+			return String.format("Invalid setLevel argument, value must be number but \"%s\" was given.", value);
+		}
+	}
+
+	@RequiredArgsConstructor
+	public static class InvalidTypeArgumentException extends IllegalArgumentException
+	{
+		final String type;
+
+		@Override
+		public String getMessage()
+		{
+			return String.format("Invalid setLevel argument, type must be one of [level, exp] but \"%s\" was given.", type);
+		}
+	}
+
+}

--- a/src/main/java/dev/hollink/bankstanding/state/player/PlayerStateManager.java
+++ b/src/main/java/dev/hollink/bankstanding/state/player/PlayerStateManager.java
@@ -9,8 +9,10 @@ import java.time.Instant;
 import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
@@ -21,6 +23,7 @@ import net.runelite.api.events.ChatMessage;
 import static dev.hollink.bankstanding.config.TimeConstants.GRACE_PERIOD_CHATTING;
 import static dev.hollink.bankstanding.config.TimeConstants.GRACE_PERIOD_GRINDING;
 import static dev.hollink.bankstanding.config.TimeConstants.GRACE_PERIOD_MOVEMENT;
+import static dev.hollink.bankstanding.config.TimeConstants.TIME_TILL_INITIAL_EXP;
 import static net.runelite.api.ChatMessageType.CLAN_CHAT;
 import static net.runelite.api.ChatMessageType.PRIVATECHATOUT;
 import static net.runelite.api.ChatMessageType.PUBLICCHAT;
@@ -34,6 +37,7 @@ public class PlayerStateManager
 	private final BankstandingEventBus events;
 
 	@Getter
+	@Setter(AccessLevel.PACKAGE)
 	private PlayerState currentPlayerState;
 
 	@Getter
@@ -50,7 +54,7 @@ public class PlayerStateManager
 		currentPlayerState = new PlayerState(Instant.now(), ActivityState.NULL);
 
 		lastExperienceDrop = new Activity<>(client.getOverallExperience(), Instant.EPOCH);
-		lastMovement = new Activity<>(client.getLocalPlayer().getWorldLocation(), Instant.EPOCH);
+		lastMovement = new Activity<>(client.getLocalPlayer().getWorldLocation(), Instant.now());
 		lastChatMessage = new Activity<>(null, Instant.EPOCH);
 
 		log.debug("PlayerStateManager started");
@@ -58,6 +62,12 @@ public class PlayerStateManager
 
 	public void checkForStateChanges()
 	{
+		if (isWithinInitialGracePeriod())
+		{
+			// wait till the initial grace period is over!
+			return;
+		}
+
 		updateActivityTimers();
 
 		ActivityState activity = determineCurrentActivity();
@@ -65,6 +75,12 @@ public class PlayerStateManager
 		{
 			currentPlayerState = switchActivity(activity);
 		}
+	}
+
+	private boolean isWithinInitialGracePeriod()
+	{
+		return currentPlayerState.getActivity().equals(ActivityState.NULL)
+			&& currentPlayerState.getSince().isAfter(Instant.now().minus(TIME_TILL_INITIAL_EXP));
 	}
 
 	public void onChatMessage(ChatMessage event)

--- a/src/test/java/dev/hollink/bankstanding/state/player/PlayerStateManagerTest.java
+++ b/src/test/java/dev/hollink/bankstanding/state/player/PlayerStateManagerTest.java
@@ -1,6 +1,7 @@
 package dev.hollink.bankstanding.state.player;
 
 import dev.hollink.bankstanding.config.ActivityState;
+import dev.hollink.bankstanding.domain.PlayerState;
 import dev.hollink.bankstanding.events.BankstandingEvent;
 import dev.hollink.bankstanding.events.BankstandingEventBus;
 import dev.hollink.bankstanding.events.BankstandingPlayerStateChangedEvent;
@@ -43,6 +44,9 @@ public class PlayerStateManagerTest
 
 		playerStateManager = new PlayerStateManager(mockClient, mockEventBus);
 		playerStateManager.startUp();
+
+		// Set null state way back to skip the grace period.
+		playerStateManager.setCurrentPlayerState(new PlayerState(Instant.EPOCH, ActivityState.NULL));
 	}
 
 	@Test
@@ -109,14 +113,9 @@ public class PlayerStateManagerTest
 	@Test
 	public void movementUpdate_shouldUpdateLastMovement_ifDistanceExceeded()
 	{
-		WorldPoint initialLocation = new WorldPoint(0, 0, 0);
-		WorldPoint movedLocation = new WorldPoint(10, 0, 0);
-
-		when(mockPlayer.getWorldLocation()).thenReturn(initialLocation);
-		playerStateManager.startUp();
-
+		WorldPoint startLocation = GRAND_EXCHANGE.getCenterPoint();
+		WorldPoint movedLocation = new WorldPoint(startLocation.getX() + 10, startLocation.getY() - 10, 0);
 		when(mockPlayer.getWorldLocation()).thenReturn(movedLocation);
-
 		Instant before = playerStateManager.getLastMovement().getTime();
 
 		playerStateManager.checkForStateChanges();


### PR DESCRIPTION
## Summary
Currently there is an initial grace period before exp is awarded. This grace period happens each time the player switches from state. 

This was not the inent of the initial grace period. Its meant to block exp being gained shortly after logging in.

Within the proposed changes is a check on startup, when the player state is NULL. The initial grace period will end after 2 minutes and state changes will only use their configured grace times.

## Type of Change
- [ ] Bug fix
- [ ] Feature
- [x] Refactor

## Related Issue
No related issues.

## Checklist
- [x] Code follows RuneLite conventions
- [ ] Manual in-game testing
- [x] Overlay rendering optimized
- [x] Verified with different config combinations
- [x] No breaking config changes
