### PR TITLE
Rename the 'lvl bankstanding' command to just 'bankstanding'

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Runelite plugin that awards you for doing nothing!
 * It uses this information to see 'how afk' the player is
 * Awards the player experience points in Bankstanding for the time spent idle.
 * Adds an overlay indicating the current level and progress to level-up.
-* Adds an "!lvl bankstanding" command to brag about how AFK you have been.
+* Adds a "!bankstanding"-command to brag about how AFK you have been.
 * Additionally, tracks time spent in the banks or Gielinor.
 * Provides a side panel with time spent idle/active and shows visits per bank.
 

--- a/src/main/java/dev/hollink/bankstanding/BankstandingPlugin.java
+++ b/src/main/java/dev/hollink/bankstanding/BankstandingPlugin.java
@@ -91,11 +91,10 @@ public class BankstandingPlugin extends Plugin
 		overlayManager.init();
 		levelUpHandler.init();
 
-		chatCommandManager.registerCommand("!lvl", chatCommandHandler::handleLevelCommand);
+		chatCommandManager.registerCommand("!bankstanding", chatCommandHandler::handleLevelCommand);
 		if (developerMode) {
 			chatCommandManager.registerCommand("!setBankstanding", chatCommandHandler::handleSetLevelCommand);
 		}
-
 		clientToolbar.addNavigation(navButton = buildNavButton());
 	}
 
@@ -109,7 +108,7 @@ public class BankstandingPlugin extends Plugin
 		levelUpHandler.destroy();
 		progressOverlayStateManager.destroy();
 
-		chatCommandManager.unregisterCommand("!lvl");
+		chatCommandManager.unregisterCommand("!bankstanding");
 		if (developerMode) {
 			chatCommandManager.unregisterCommand("!setBankstanding");
 		}

--- a/src/main/java/dev/hollink/bankstanding/state/level/LevelCommandHandler.java
+++ b/src/main/java/dev/hollink/bankstanding/state/level/LevelCommandHandler.java
@@ -48,24 +48,10 @@ public class LevelCommandHandler implements CommandHandler
 
 	public void handleCommand(ChatMessage chatMessage, String message)
 	{
-		String[] args = message.split(" ");
-		log.debug("Received level command: {}", Arrays.toString(args));
-		if (args.length != 2)
-		{
-			return;
-		}
-
-		String category = args[1].toLowerCase();
-		switch (category)
-		{
-			case "bs":
-			case "bankstanding":
-				sendLevelResponse(
-					chatMessage,
-					"Bankstanding",
-					xpManager.getBankstanding().getCurrentLevel(),
-					(int) xpManager.getBankstanding().getExperience());
-				break;
-		}
+		sendLevelResponse(
+			chatMessage,
+			"Bankstanding",
+			xpManager.getBankstanding().getCurrentLevel(),
+			(int) xpManager.getBankstanding().getExperience());
 	}
 }

--- a/src/test/java/dev/hollink/bankstanding/state/level/LevelCommandHandlerTest.java
+++ b/src/test/java/dev/hollink/bankstanding/state/level/LevelCommandHandlerTest.java
@@ -49,7 +49,7 @@ public class LevelCommandHandlerTest
 		BankstandingLevel level = new BankstandingLevel(10);
 		when(mockXpManager.getBankstanding()).thenReturn(level);
 
-		commandHandler.handleCommand(mockChatMessage, "!level bankstanding");
+		commandHandler.handleCommand(mockChatMessage, "!bankstanding");
 
 		verify(mockMessageNode).setRuneLiteFormatMessage(
 			contains("Bankstanding")
@@ -58,39 +58,4 @@ public class LevelCommandHandlerTest
 		verify(mockClient).refreshChat();
 	}
 
-	@Test
-	public void handleCommand_shouldSendLevelResponse_forBsShortcut()
-	{
-		BankstandingLevel level = new BankstandingLevel(15);
-		when(mockXpManager.getBankstanding()).thenReturn(level);
-
-		commandHandler.handleCommand(mockChatMessage, "!level bs");
-
-		verify(mockMessageNode).setRuneLiteFormatMessage(
-			contains("Bankstanding")
-		);
-		verify(mockClient).refreshChat();
-	}
-
-	@Test
-	public void handleCommand_shouldNotSendMessage_forUnknownCategory()
-	{
-		BankstandingLevel level = new BankstandingLevel(10);
-		when(mockXpManager.getBankstanding()).thenReturn(level);
-
-		commandHandler.handleCommand(mockChatMessage, "!level unknown");
-
-		verify(mockMessageNode, never()).setRuneLiteFormatMessage(any());
-		verify(mockClient, never()).refreshChat();
-	}
-
-	@Test
-	public void handleCommand_shouldIgnoreIncorrectArguments()
-	{
-		commandHandler.handleCommand(mockChatMessage, "!level");
-		commandHandler.handleCommand(mockChatMessage, "!level a b c");
-
-		verify(mockMessageNode, never()).setRuneLiteFormatMessage(any());
-		verify(mockClient, never()).refreshChat();
-	}
 }


### PR DESCRIPTION
## Summary
Fixes the collision with the existing `!lvl` command in `chat-commands` plugin

## Type of Change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor

## Related Issue
Closes #22 
